### PR TITLE
Revert "Bump goreleaser/goreleaser-action from 3 to 4"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
Reverts hansmi/baamhackl#12 as it breaks the build: "git tag v0.0.2 was not made against commit 763eac6a07fac296afadeb5cc7dd6729fa4057b9".